### PR TITLE
Bug: Fixed entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /app
 
 COPY --from=builder /app/kscale .
 
-ENTRYPOINT /app
+ENTRYPOINT ["/app/kscale"]


### PR DESCRIPTION
The Dockerfile contained an invalid `ENTRYPOINT`. It worked before KScale was uploaded to GitHub, but I forgot to change the `ENTRYPOINT` when I optimised the Dockerfile.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #4

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- It starts up when it's being run.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.