### PR TITLE
Improvement: Using base image `scratch` instead of `alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /app
 
 COPY . .
 
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
+
 RUN go mod download
 RUN go build -o ./kscale .
 
-FROM alpine:3.14
+FROM scratch
 
-WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/kscale /go/bin/kscale
 
-COPY --from=builder /app/kscale .
-
-ENTRYPOINT ["/app/kscale"]
+ENTRYPOINT ["/go/bin/kscale"]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Improvement.

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Container image is using `alpine` as base image.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

When building the container image, it was using `Alpine` before and now I switched it to `scratch` for two reasons.
1. Changing the base image reduced the image size by 9,63%.
2. `scratch` is said to be more secure.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->