### PR TITLE
Bump @bestsellerit/secret-injector from 2.8.3 to 2.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ filter: &filter
       only: /.*/
 
 orbs:
-  secret-injector: bestsellerit/secret-injector@2.8.3
+  secret-injector: bestsellerit/secret-injector@2.9.0
   cci-common: bestsellerit/cci-common@4.1.0
 
 commands:


### PR DESCRIPTION
> [!WARNING]
> We are shutting down the managed version of `dependabot-circleci` on May 1, 2025. So after this date, you will no longer receive any more pull requests.

dependabot-circleci/orb/bestsellerit/secret-injector@2.9.0